### PR TITLE
fix: move custom selectors into mixins.css

### DIFF
--- a/system/mixins.css
+++ b/system/mixins.css
@@ -9,3 +9,23 @@
 @import './mixins/form';
 @import './mixins/icons';
 @import './mixins/resets';
+
+@custom-selector :--heading h1, h2, h3, h4, h5, .h1, .h2, .h3, .h4, .h5;
+@custom-selector :--display .display1, .display2, .display3;
+@custom-selector :--eyebrow
+  h1.eyebrow,
+  h2.eyebrow,
+  h3.eyebrow,
+  h4.eyebrow,
+  h5.eyebrow,
+  p.eyebrow,
+  .eyebrow;
+@custom-selector :--subtitle
+  h1.subtitle,
+  h2.subtitle,
+  h3.subtitle,
+  h4.subtitle,
+  h5.subtitle,
+  h6.subtitle,
+  p.subtitle,
+  .subtitle;

--- a/system/typography.css
+++ b/system/typography.css
@@ -1,25 +1,5 @@
 @import './mixins';
 
-@custom-selector :--heading h1, h2, h3, h4, h5, .h1, .h2, .h3, .h4, .h5;
-@custom-selector :--display .display1, .display2, .display3;
-@custom-selector :--eyebrow
-  h1.eyebrow,
-  h2.eyebrow,
-  h3.eyebrow,
-  h4.eyebrow,
-  h5.eyebrow,
-  p.eyebrow,
-  .eyebrow;
-@custom-selector :--subtitle
-  h1.subtitle,
-  h2.subtitle,
-  h3.subtitle,
-  h4.subtitle,
-  h5.subtitle,
-  h6.subtitle,
-  p.subtitle,
-  .subtitle;
-
 .display1 {
   @mixin display1;
 }


### PR DESCRIPTION
Clients only include mixins.css so we need to move custom typography selectors into there